### PR TITLE
Improve/fix Location.compareTo()

### DIFF
--- a/src/edu/boun/edgecloudsim/utils/Location.java
+++ b/src/edu/boun/edgecloudsim/utils/Location.java
@@ -148,13 +148,25 @@ public class Location implements Comparable {
 	 */
 	public int compareTo(Object _in) {
 		Location in = (Location) _in;
-		if (xPos == in.getXPos() && yPos == in.getYPos() && altitude ==  in.altitude) {
-			return 0;
+//		if (xPos == in.getXPos() && yPos == in.getYPos() && altitude ==  in.altitude) {
+//			return 0;
+//		}
+//		else if (xPos > in.getXPos()) {
+//			return 1;
+//		}
+//		else return -1;
+
+		// Changed by Chengyu Tang to prevent errors caused by using TreeSet (e.g., NetworkTopology.validateTopology)
+		if (xPos == in.getXPos()) {
+			if (yPos == in.getYPos()) {
+				if (altitude == in.getAltitude()) {
+					return 0;
+				}
+				return altitude > in.getAltitude() ? 1 : -1;
+			}
+			return yPos > in.getYPos() ? 1 : -1;
 		}
-		else if (xPos > in.getXPos()) {
-			return 1;
-		}
-		else return -1;
+		return xPos > in.getXPos() ? 1 : -1;
 	}
 	
 	

--- a/src/edu/boun/edgecloudsim/utils/Location.java
+++ b/src/edu/boun/edgecloudsim/utils/Location.java
@@ -148,13 +148,6 @@ public class Location implements Comparable {
 	 */
 	public int compareTo(Object _in) {
 		Location in = (Location) _in;
-//		if (xPos == in.getXPos() && yPos == in.getYPos() && altitude ==  in.altitude) {
-//			return 0;
-//		}
-//		else if (xPos > in.getXPos()) {
-//			return 1;
-//		}
-//		else return -1;
 
 		// Changed by Chengyu Tang to prevent errors caused by using TreeSet (e.g., NetworkTopology.validateTopology)
 		if (xPos == in.getXPos()) {


### PR DESCRIPTION
The current implementation of [`Location.compareTo()`](https://github.com/baskiyar/PFogSim-Mango/blob/9aac7d45a993c95cc08e3ddc7c2c37c552a90769/src/edu/boun/edgecloudsim/utils/Location.java#L149) only compares the longitudes (xPos) of two Location objects, ignoring their `yPos` and `altitude`. This can cause problems. This PR changes the behavior of `Location.compareTo()`. Two locations are compared lexicographically in the order of xPos, yPos, and altitude to avoid potentially undesired results. 

For example, when there are two or more locations with the same xPos, [`NetworkTopology.validateTopology()`](https://github.com/baskiyar/PFogSim-Mango/blob/9aac7d45a993c95cc08e3ddc7c2c37c552a90769/src/edu/auburn/pFogSim/netsim/NetworkTopology.java#L125) may fail as it cannot find certain coordinate(s) in `NetworkTopology.coords` because `coords` is declared as a `TreeSet`, which uses the `compareTo()` method to check the presence of an element. In the default Chicago dataset, every `xPos` and `yPos` is unique, so it won't cause problems. But if we want to use a different set of locations, like the minimal example below, the topology validation will fail with error "`rlink not in coords`".

|        | lat (y)   | lon (x)    |
|--------|-----------|------------|
| layer1 | 32.606180 | -85.488739 |
| layer2 | 32.607180 | -85.488739 |
| layer3 | 32.608180 | -85.488739 |
| layer4 | 32.609180 | -85.488739 |
| layer5 | 32.610180 | -85.488739 |
| layer6 | 32.611180 | -85.488739 |
| layer7 | 41.2215833 | -95.8638667|

Another obvious fix is to let `NetworkTopology.coords` be a `HashSet`, which uses the `equals()` method instead of `compareTo()`, but the impact of making such change is unclear.